### PR TITLE
Add support for Gitlab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added command `list-owners` that lists all owners specified in the CODEOWNERS file
+- Add `.gitlab/` to the locations where a CODEOWNERS file is searched ([#6](https://github.com/timoschinkel/codeowners-cli/issues/6))
 
 ### Changed
 - Renamed `\CodeOwners\Cli\Tests\Command\ListCommandTest` to `\CodeOwners\Cli\Tests\Command\ListFilesCommandTest`
 - Updated required version of `timoschinkel/codeowners` to `^1.1.0`
+- Changed order for searching `CODEOWNERS` file to `.github/|.gitlab/|.bitbucket/` > `root` > `docs/` ([#6](https://github.com/timoschinkel/codeowners-cli/issues/6))
 
 ## [1.0.0] - 2020-01-08
 ### Added

--- a/README.md
+++ b/README.md
@@ -42,7 +42,11 @@ All commands have the options supplied by Symfony Console:
 When no CODEOWNERS file is specified - using `-c` or `--codeowners` - the application will search the CODEOWNERS file in the following locations based on the working directory:
 * `<working_dir>/.github/CODEOWNERS`
 * `<working_dir>/.bitbucket/CODEOWNERS`
+* `<working_dir>/.gitlab/CODEOWNERS`
 * `<working_dir>/CODEOWNERS`
+* `<working_dir>/docs/CODEOWNERS`
+
+Calling the command with the verbose option will print what file is used when applicable.
 
 ### Available commands
 #### `owner`

--- a/src/FileLocator/SearchFileLocator.php
+++ b/src/FileLocator/SearchFileLocator.php
@@ -20,10 +20,14 @@ final class SearchFileLocator implements FileLocatorInterface
      */
     public function locateFile(): string
     {
+        // Direct answer from Github: order is `.github/` > `root` > `docs/`
+        // This is extrapolated to Gitlab and Bitbucket
         $suggestions = [
             "{$this->workingDirectory}/.github/CODEOWNERS",
             "{$this->workingDirectory}/.bitbucket/CODEOWNERS",
+            "{$this->workingDirectory}/.gitlab/CODEOWNERS",
             "{$this->workingDirectory}/CODEOWNERS",
+            "{$this->workingDirectory}/docs/CODEOWNERS",
         ];
 
         foreach ($suggestions as $suggestion) {

--- a/tests/FileLocator/SearchFileLocatorTest.php
+++ b/tests/FileLocator/SearchFileLocatorTest.php
@@ -45,6 +45,20 @@ final class SearchFileLocatorTest extends TestCase
                 ],
                 '/.bitbucket/CODEOWNERS',
             ],
+            'prioritize .gitlab over root' => [
+                [
+                    'CODEOWNERS' => '#',
+                    '.gitlab' => ['CODEOWNERS' => '#']
+                ],
+                '/.gitlab/CODEOWNERS',
+            ],
+            'prioritize root over docs/' => [
+                [
+                    'CODEOWNERS' => '#',
+                    'docs' => ['CODEOWNERS' => '#']
+                ],
+                '/CODEOWNERS',
+            ],
         ];
     }
 


### PR DESCRIPTION
- Add support for Gitlab when searching for a CODEOWNERS file
- Change the order in which is searched for a CODEOWNERS file after an answer from Github to `.github/|.bitbucket/|.gitlab/` > `root` > `docs/`

Fixes #6