### PR TITLE
Mark PHP 8 as supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 php:
   - '7.3'
   - '7.4'
+  - 'nightly'
 
 before_script:
   - composer install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.0] - 2020-11-29
 ### Added
 - Added development dependency to `phpspec/prophecy-phpunit`
 
 ### Changed
-- Updated PHP requirements from `^7.2` to `^7.3`
+- Updated PHP requirements from `^7.2` to `^7.3 || ^8.0`
 - Updated Psalm requirements to `^4.2`
 - Updated PHPUnit requirements to `^9.4`
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "Apache-2.0",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ^8.0",
         "symfony/console": "^5.0",
         "timoschinkel/codeowners": "^1.1.0",
         "symfony/finder": "^5.0"


### PR DESCRIPTION
- Run Travis inspections on PHP 8
- Update PHP requirements from `^7.3` to `^7.3 || ^8.0`