### PR TITLE
Upgrade `timoschinkel/codeowners` to `^2.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.1] - 2021-10-27
 ### Changed
 - Switched inspections from Travis to Github Actions
+- Updated the requirement for `timoschinkel/codeowners` to at least `2.0.0`
 
 ## [1.3.0] - 2020-12-08
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "symfony/console": "^5.0",
-        "timoschinkel/codeowners": "^1.1.0",
+        "timoschinkel/codeowners": "^2.0",
         "symfony/finder": "^5.0"
     },
     "bin": ["bin/codeowners"],

--- a/src/Command/ListOwnersCommand.php
+++ b/src/Command/ListOwnersCommand.php
@@ -72,7 +72,7 @@ final class ListOwnersCommand extends Command
 
         $owners = [];
 
-        foreach ($this->parser->parse($codeownersFile) as $pattern) {
+        foreach ($this->parser->parseFile($codeownersFile) as $pattern) {
             $owners = array_merge($owners, $pattern->getOwners());
         }
 

--- a/src/PatternMatcherFactory.php
+++ b/src/PatternMatcherFactory.php
@@ -12,6 +12,6 @@ final class PatternMatcherFactory implements PatternMatcherFactoryInterface
 {
     public function getPatternMatcher(string $file): PatternMatcherInterface
     {
-        return new PatternMatcher(...(new Parser())->parse($file));
+        return new PatternMatcher(...(new Parser())->parseFile($file));
     }
 }

--- a/tests/Command/ListOwnersCommandTest.php
+++ b/tests/Command/ListOwnersCommandTest.php
@@ -60,7 +60,7 @@ final class ListOwnersCommandTest extends TestCase
             ->willReturn($fileLocator->reveal());
 
         $this->parser
-            ->parse($filesystem->url() . '/CODEOWNERS')
+            ->parseFile($filesystem->url() . '/CODEOWNERS')
             ->shouldBeCalled()
             ->willReturn([
                 new Pattern('pattern 01', ['owner 01', 'owner 02']),


### PR DESCRIPTION
Upgrade the usage of `timoschinkel/codeowners` to the latest version by changing the requirement to `^2.0`.