### PR TITLE
Feature/update requirements

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1']
+        php-versions: ['8.0', '8.1']
     name: PHP ${{ matrix.php-versions }}
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - Unreleased
+### Added
+- Version output to `codeowners --version`
+
+### Changed
+- Increased requirements for `symfony/console` and `symfony/finder` to `^6.0`
+- Increased requirements for `php` to `^8.0, <8.2`
+
 ## [1.3.1] - 2021-10-27
 ### Changed
 - Switched inspections from Travis to Github Actions

--- a/bin/codeowners
+++ b/bin/codeowners
@@ -28,7 +28,7 @@ $workingDir = realpath('.');
 $fileLocatorFactory = new FileLocatorFactory();
 $patternMatcherFactory = new PatternMatcherFactory();
 
-$app = new Application('Code owners CLI');
+$app = new Application('Code owners CLI', '1.4.0');
 
 $app->addCommands([
     new OwnerCommand($workingDir, $fileLocatorFactory, $patternMatcherFactory),

--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,10 @@
     "type": "project",
     "license": "Apache-2.0",
     "require": {
-        "php": "^7.3 || ^8.0",
-        "symfony/console": "^5.0",
+        "php": "^8.0, <8.2",
+        "symfony/console": "^6.0",
         "timoschinkel/codeowners": "^2.0",
-        "symfony/finder": "^5.0"
+        "symfony/finder": "^6.0"
     },
     "bin": ["bin/codeowners"],
     "autoload": {


### PR DESCRIPTION
The autocomplete functionality is introduced in `symfony/console` version 5.4 and 6.0. Given the current supported PHP versions this would be a nice moment to move to the latest and greatest, so 6.0 and PHP version 8. This is the first step; Updating the requirements.

PHP has been introducing backwards incompatibilities in minor versions - see https://www.php.net/manual/en/migration81.incompatible.php - so I'm opting to exclude any non-final non-tested PHP versions.

- Update PHP version requirement to `^8.0, < 8.2`
- Update `symfony/console` and `symfony/finder` requirement to `^6.0`
- Update GitHub Actions to only run for PHP 8.0 and 8.1
- Add version number output to `codeowners --version`