### PR TITLE
[Release] 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.4.0] - Unreleased
+## [1.4.0] - 2022-12-09
 ### Added
 - Version output to `codeowners --version`
 
 ### Changed
 - Increased requirements for `symfony/console` and `symfony/finder` to `^6.0`
-- Increased requirements for `php` to `^8.0, <8.2`
+- Increased requirements for `php` to `^8.0, <8.3`
 
 ## [1.3.1] - 2021-10-27
 ### Changed


### PR DESCRIPTION
### Added
- Version output to `codeowners --version`

### Changed
- Increased requirements for `symfony/console` and `symfony/finder` to `^6.0`
- Increased requirements for `php` to `^8.0, <8.3`