### PR TITLE
Supported php versions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2']
+        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4']
     name: PHP ${{ matrix.php-versions }}
 
     steps:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4']
+        php-versions: ['8.1', '8.2', '8.3', '8.4']
     name: PHP ${{ matrix.php-versions }}
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2025-01-29
+### Removed
+- Dropped support for PHP 8.0
+
+### Added
+- Inspections - and thus support - for PHP 8.3 and 8.4 
+
 ## [1.4.0] - 2022-12-09
 ### Added
 - Version output to `codeowners --version`

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "Apache-2.0",
     "require": {
-        "php": "^8.0, <8.5",
+        "php": "^8.0",
         "symfony/console": "^6.0",
         "timoschinkel/codeowners": "^2.0",
         "symfony/finder": "^6.0"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.5",
-        "vimeo/psalm": "^4.2",
+        "vimeo/psalm": "^5.26",
         "phpunit/phpunit": "^9.4",
         "mikey179/vfsstream": "^1.6",
         "phpspec/prophecy-phpunit": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "Apache-2.0",
     "require": {
-        "php": "^8.0, <8.3",
+        "php": "^8.0, <8.5",
         "symfony/console": "^6.0",
         "timoschinkel/codeowners": "^2.0",
         "symfony/finder": "^6.0"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.5",
-        "vimeo/psalm": "^5.26",
+        "vimeo/psalm": "^6.0",
         "phpunit/phpunit": "^9.4",
         "mikey179/vfsstream": "^1.6",
         "phpspec/prophecy-phpunit": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "Apache-2.0",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "symfony/console": "^6.0",
         "timoschinkel/codeowners": "^2.0",
         "symfony/finder": "^6.0"

--- a/psalm.xml
+++ b/psalm.xml
@@ -49,5 +49,7 @@
         <RawObjectIteration errorLevel="info" />
 
         <InvalidStringClass errorLevel="info" />
+
+        <UnusedClass errorLevel="suppress" />
     </issueHandlers>
 </psalm>

--- a/src/Command/ListFilesCommand.php
+++ b/src/Command/ListFilesCommand.php
@@ -116,7 +116,7 @@ final class ListFilesCommand extends Command
         // not support `realpath`.
         return array_map(
             function (string $path): string {
-                return realpath($path) ?: $path;
+                return realpath($path) !== false ? realpath($path) : $path;
             },
             $paths
         );

--- a/src/Command/ListFilesCommand.php
+++ b/src/Command/ListFilesCommand.php
@@ -116,7 +116,8 @@ final class ListFilesCommand extends Command
         // not support `realpath`.
         return array_map(
             function (string $path): string {
-                return realpath($path) !== false ? realpath($path) : $path;
+                $realpath = realpath($path);
+                return $realpath !== false ? $realpath : $path;
             },
             $paths
         );

--- a/src/Command/ListUnownedFilesCommand.php
+++ b/src/Command/ListUnownedFilesCommand.php
@@ -106,7 +106,7 @@ final class ListUnownedFilesCommand extends Command
         // not support `realpath`.
         return array_map(
             function (string $path): string {
-                return realpath($path) ?: $path;
+                return realpath($path) !== false ? realpath($path) : $path;
             },
             $paths
         );

--- a/src/Command/ListUnownedFilesCommand.php
+++ b/src/Command/ListUnownedFilesCommand.php
@@ -106,7 +106,8 @@ final class ListUnownedFilesCommand extends Command
         // not support `realpath`.
         return array_map(
             function (string $path): string {
-                return realpath($path) !== false ? realpath($path) : $path;
+                $realpath = realpath($path);
+                return $realpath !== false ? $realpath : $path;
             },
             $paths
         );

--- a/src/FileLocator/FileLocatorFactory.php
+++ b/src/FileLocator/FileLocatorFactory.php
@@ -8,7 +8,7 @@ final class FileLocatorFactory implements FileLocatorFactoryInterface
 {
     public function getFileLocator(string $workingDirectory, string $specifiedFile = null): FileLocatorInterface
     {
-        return empty($specifiedFile) === false
+        return $specifiedFile !== null
             ? new SpecifiedFileLocator($specifiedFile)
             : new SearchFileLocator($workingDirectory);
     }


### PR DESCRIPTION
Now that PHP 8.4 has officially been released the inspections can be run on PHP version 8.3 and 8.4 as well.

Edit: [Psalm](https://packagist.org/packages/vimeo/psalm) is explicitly not yet supporting PHP 8.4. I expect this will happen on short notice.