### PR TITLE
Introduce `--strict` flag to `list-unowned-files` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2025-01-29
+### Added
+- Optional option `--strict` for `list-unowned-files` to make the command usable in CI ([#23](https://github.com/timoschinkel/codeowners-cli/pull/23))
+
 ## [1.4.1] - 2025-01-29
 ### Removed
 - Dropped support for PHP 8.0

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Arguments:
 
 Options:
   -c, --codeowners=CODEOWNERS  Location of code owners file, defaults to <working_dir>/CODEOWNERS
+      --strict                 Return a non-zero exit code when there are unowned files
 ```
 
 For example:


### PR DESCRIPTION
Introduce `--strict` flag to `list-unowned-files` command, which will make this command very usable in a CI environment.

solves #22