### PR TITLE
Support Symfony 7.0 (and 6.0)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,7 +8,8 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.1', '8.2', '8.3', '8.4']
-    name: PHP ${{ matrix.php-versions }}
+        symfony-versions: ['^6.0', '^7.0']
+    name: PHP ${{ matrix.php-versions }} with Symfony ${{ matrix.symfony-versions }}
 
     steps:
       - uses: actions/checkout@v2
@@ -17,8 +18,10 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           coverage: xdebug
-      - name: Install dependencies
+      - name: Install dependencies # Verify that the package can be installed for current environment
         run: composer install --prefer-dist --no-progress --no-suggest
+      - name: Configure Symfony    # Specify desired Symfony version
+        run: composer update --with symfony/console:${{ matrix.symfony-versions }} --with symfony/finder:${{ matrix.symfony-versions }} --ignore-platform-reqs -W
       - name: Unit tests
         run: ./vendor/bin/phpunit
       - name: Static Analysis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2025-01-30
+### Added
+- Support for Symfony 7 (next to Symfony 6) ([#24](https://github.com/timoschinkel/codeowners-cli/pull/24))
+
 ## [1.5.0] - 2025-01-29
 ### Added
 - Optional option `--strict` for `list-unowned-files` to make the command usable in CI ([#23](https://github.com/timoschinkel/codeowners-cli/pull/23))

--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,9 @@
     "license": "Apache-2.0",
     "require": {
         "php": "^8.1",
-        "symfony/console": "^6.0",
+        "symfony/console": "^6.0|^7.0",
         "timoschinkel/codeowners": "^2.0",
-        "symfony/finder": "^6.0"
+        "symfony/finder": "^6.0|^7.0"
     },
     "bin": ["bin/codeowners"],
     "autoload": {


### PR DESCRIPTION
The differences between Symfony 6 and 7 do not affect this codebase (yet). This means we might as well support both versions. This also adds some GHA/Composer changes to run inspections on supported PHP versions, but also on both Symfony versions. Symfony is way faster with dropping support for languages, so I added `--ignore-platform-req=php+` to deal with this.