### PR TITLE
Solve implicitly nullable parameters

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.1', '8.2', '8.3', '8.4']
+        php-versions: ['8.2', '8.3', '8.4']
         symfony-versions: ['^6.0', '^7.0']
     name: PHP ${{ matrix.php-versions }} with Symfony ${{ matrix.symfony-versions }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Solve implicitly nullable parameters to better support PHP 8.4 ([#27](https://github.com/timoschinkel/codeowners-cli/pull/27))
 
+### Removed 
+- Support for PHP 8.1 ([#27](https://github.com/timoschinkel/codeowners-cli/pull/27))
+
 ## [1.6.0] - 2025-05-28
 ### Added
 - `-o`/`--owner-only` option for `codeowners owner` to print only the owner ([#26](https://github.com/timoschinkel/codeowners-cli/pull/26))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2026-03-10
+### Changed
+- Solve implicitly nullable parameters to better support PHP 8.4 ([#27](https://github.com/timoschinkel/codeowners-cli/pull/27))
+
 ## [1.6.0] - 2025-05-28
 ### Added
 - `-o`/`--owner-only` option for `codeowners owner` to print only the owner ([#26](https://github.com/timoschinkel/codeowners-cli/pull/26))

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "Apache-2.0",
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "symfony/console": "^6.0|^7.0",
         "timoschinkel/codeowners": "^2.0",
         "symfony/finder": "^6.0|^7.0"

--- a/src/FileLocator/FileLocatorFactory.php
+++ b/src/FileLocator/FileLocatorFactory.php
@@ -6,7 +6,7 @@ namespace CodeOwners\Cli\FileLocator;
 
 final class FileLocatorFactory implements FileLocatorFactoryInterface
 {
-    public function getFileLocator(string $workingDirectory, string $specifiedFile = null): FileLocatorInterface
+    public function getFileLocator(string $workingDirectory, ?string $specifiedFile = null): FileLocatorInterface
     {
         return $specifiedFile !== null
             ? new SpecifiedFileLocator($specifiedFile)

--- a/src/FileLocator/FileLocatorFactoryInterface.php
+++ b/src/FileLocator/FileLocatorFactoryInterface.php
@@ -6,5 +6,5 @@ namespace CodeOwners\Cli\FileLocator;
 
 interface FileLocatorFactoryInterface
 {
-    public function getFileLocator(string $workingDirectory, string $specifiedFile = null): FileLocatorInterface;
+    public function getFileLocator(string $workingDirectory, ?string $specifiedFile = null): FileLocatorInterface;
 }


### PR DESCRIPTION
Make nullable parameters explicitly nullable to prevent deprecation warnings on PHP 8.4, see https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated.

Newer versions of PHPUnit can detect these things, but I'll look at that at a later time.

Explicit nullable is not very compatible with PHP 8.1. And since PHP 8.1 is pretty outdated we should be able to drop this. Users still on PHP 8.1 can use the current version as the changes in 1.6.1 are purely meant for PHP 8.4.