### PR TITLE
Update requirement `timoschinkel/codeowners`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.1] - 2026-05-04
+### Changed
+- Update requirement for `timoschinkel/codeowners` to `^2.0|^3.0` ([#31](https://github.com/timoschinkel/codeowners-cli/pull/31))
+
 ## [1.7.0] - 2026-03-19
 ### Added 
 - Support for Symfony 8 ([#29](https://github.com/timoschinkel/codeowners-cli/pull/29))

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^8.2",
         "symfony/console": "^6.0|^7.0|^8.0",
-        "timoschinkel/codeowners": "^2.0",
+        "timoschinkel/codeowners": "^2.0|^3.0",
         "symfony/finder": "^6.0|^7.0|^8.0"
     },
     "bin": ["bin/codeowners"],


### PR DESCRIPTION
`timoschinkel/codeowners` has released a new major version. The backwards compatibility breaking changes do not affect this repository, so we can update the requirement. To minimize the complexity of adopting the newer version both version 2.x and 3.x are supported.